### PR TITLE
#925 Governing Auton Name Max Char

### DIFF
--- a/components/dao/DaoNamingFields.vue
+++ b/components/dao/DaoNamingFields.vue
@@ -37,7 +37,7 @@
         class="mt-2"
         counter
         style="max-width: 450px"
-        maxlength="64"
+        maxlength="20"
         :rules="[rules.required, rules.min, rules.maxgoverningName]"
         v-model="governingNameValue"
       ></v-text-field>
@@ -81,7 +81,7 @@ export default {
     rules: {
       required: (value) => !!value || "Required.",
       min: (v) => v?.length >= 2 || "Min 2 characters",
-      maxgoverningName: (v) => v?.length <= 64 || "Max 64 characters",
+      maxgoverningName: (v) => v?.length <= 20 || "Max 64 characters",
       maxName: (v) => v?.length <= 16 || "Max 16 characters",
     },
   }),

--- a/components/dao/DaoNamingFields.vue
+++ b/components/dao/DaoNamingFields.vue
@@ -81,7 +81,7 @@ export default {
     rules: {
       required: (value) => !!value || "Required.",
       min: (v) => v?.length >= 2 || "Min 2 characters",
-      maxgoverningName: (v) => v?.length <= 20 || "Max 64 characters",
+      maxgoverningName: (v) => v?.length <= 20 || "Max 20 characters",
       maxName: (v) => v?.length <= 16 || "Max 16 characters",
     },
   }),


### PR DESCRIPTION
The limit of 20 characters on the chain is actual a good choice from data storage and fee perspective. I've therefore made the change for the front end to comply with this rather than the other way around.